### PR TITLE
Fix how urlPath is passed to rclone

### DIFF
--- a/internal/providers/dell/dell.go
+++ b/internal/providers/dell/dell.go
@@ -126,8 +126,9 @@ func initDownloaderDUP(ctx context.Context, srcURL string, filestoreCfg *config.
 		return nil, err
 	}
 
-	// upstream URL parent
-	urlPathDir := filepath.Dir(urlPath)
+	// upstream URL path
+	// Add back the trailing slash removed by filepath.Dir() otherwise this makes rclone assume the path is a file instead of a directory
+	urlPathDir := filepath.Dir(urlPath) + "/"
 	// srcURLPart includes the scheme + host + url path of the srcURL (excluding the base name)
 	srcURLPart := hostPart + urlPathDir
 

--- a/internal/providers/dell/dell_test.go
+++ b/internal/providers/dell/dell_test.go
@@ -31,7 +31,7 @@ func Test_initDownloaderDUP(t *testing.T) {
 		{
 			"https://foo/bar/baz.bin",
 			fsConfig,
-			"https://foo/bar",
+			"https://foo/bar/",
 			"",
 			nil,
 			"DUP downloader initialization",


### PR DESCRIPTION
In a newer version of rclone (1.58.1 -- https://github.com/rclone/rclone/pull/5941)
 the way the URL used to initialize a HTTP filesystem changed, so if it doesn't have a trailing
slash and the no-head option is used, the URL is assumed to be a file
instead of a directory.