### PR TITLE
Publish checksums with hash hint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,7 +126,8 @@ func LoadFirmwareManifest(ctx context.Context, manifestURL string) (map[string][
 						Component:   strings.ToLower(component),
 						UpstreamURL: fw.VendorURI,
 						Filename:    fw.Filename,
-						Checksum:    fw.MD5Sum,
+						// publish checksum with hash hint
+						Checksum: "md5sum:" + fw.MD5Sum,
 					})
 			}
 		}

--- a/internal/vendors/checksum.go
+++ b/internal/vendors/checksum.go
@@ -95,7 +95,12 @@ func SHA256ChecksumValidate(filename, checksum string) error {
 	return nil
 }
 
-func ValidateMD5Checksum(filename, checksum string) bool {
+func validateSHA256Checksum(filename, checksum string) bool {
+	err := SHA256ChecksumValidate(filename, checksum)
+	return err == nil
+}
+
+func validateMD5Checksum(filename, checksum string) bool {
 	f, err := os.Open(filename)
 	if err != nil {
 		log.Fatal(err)
@@ -111,4 +116,27 @@ func ValidateMD5Checksum(filename, checksum string) bool {
 	}
 
 	return checksum == hex.EncodeToString(h.Sum(nil))
+}
+
+// ValidateChecksum validates the file checksum matches the given value.
+// Defaults to md5 but allows for sha256 checks
+func ValidateChecksum(filename, checksum string) bool {
+	// checksum format <hint>:<checksum>
+	splittedChecksum := strings.Split(checksum, ":")
+	// default to md5 when there's no hint
+	hint := "md5sum"
+	if len(splittedChecksum) == 2 {
+		hint = splittedChecksum[0]
+	}
+
+	checksum = splittedChecksum[len(splittedChecksum)-1]
+
+	switch hint {
+	case "md5sum":
+		return validateMD5Checksum(filename, checksum)
+	case "sha256":
+		return validateSHA256Checksum(filename, checksum)
+	default:
+		return false
+	}
 }

--- a/internal/vendors/checksum_test.go
+++ b/internal/vendors/checksum_test.go
@@ -142,3 +142,45 @@ func Test_SHA256ChecksumValidate(t *testing.T) {
 		assert.Nil(t, err)
 	}
 }
+
+func Test_ValidateChecksum(t *testing.T) {
+	testfile := "/tmp/foo.blah"
+	cases := []struct {
+		name     string
+		filename string
+		checksum string
+	}{
+		{
+			"nohint",
+			testfile,
+			"803ac72f8be2eba9f985fd3be31b506c",
+		},
+		{
+			"sha256",
+			testfile,
+			"sha256:97e9269cd0514f864e6be9157998464c94776ebc7f669b449f581abdad4035f5",
+		},
+		{
+			"md5sum",
+			testfile,
+			"md5sum:803ac72f8be2eba9f985fd3be31b506c",
+		},
+	}
+
+	for _, tt := range cases {
+		_, err := os.Create(tt.filename)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = os.WriteFile(testfile, []byte(`checksum this`), 0o0600)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// nolint:gocritic
+		defer os.Remove(tt.filename)
+
+		assert.True(t, ValidateChecksum(tt.filename, tt.checksum))
+	}
+}

--- a/internal/vendors/downloader.go
+++ b/internal/vendors/downloader.go
@@ -107,7 +107,7 @@ func VerifyFile(ctx context.Context, tmpFs, srcFs rcloneFs.Fs, fw *serverservice
 
 	tmpFilename := path.Join(tmpFs.Root(), dstPath)
 
-	if !ValidateMD5Checksum(tmpFilename, fw.Checksum) {
+	if !ValidateChecksum(tmpFilename, fw.Checksum) {
 		return errors.Wrap(ErrChecksumValidate, fmt.Sprintf("tmpFilename: %s, expected checksum: %s", tmpFilename, fw.Checksum))
 	}
 
@@ -276,7 +276,7 @@ func DownloadFirmwareArchive(ctx context.Context, tmpDir, archiveURL, archiveChe
 	}
 
 	if archiveChecksum != "" {
-		if !ValidateMD5Checksum(zipArchivePath, archiveChecksum) {
+		if !ValidateChecksum(zipArchivePath, archiveChecksum) {
 			return "", errors.Wrap(ErrChecksumValidate, fmt.Sprintf("zipArchivePath: %s, expected checksum: %s", zipArchivePath, archiveChecksum))
 		}
 	}
@@ -342,7 +342,7 @@ func ExtractFromZipArchive(archivePath, firmwareFilename, firmwareChecksum strin
 		}
 	}
 
-	if firmwareChecksum != "" && !ValidateMD5Checksum(out.Name(), firmwareChecksum) {
+	if firmwareChecksum != "" && !ValidateChecksum(out.Name(), firmwareChecksum) {
 		return nil, errors.Wrap(ErrChecksumValidate, fmt.Sprintf("firmware: %s, expected checksum: %s", out.Name(), firmwareChecksum))
 	}
 


### PR DESCRIPTION
Add function to verify checksum according to given hint, defaulting to md5 in case of no hint.