### PR TITLE
Add Filename param listing fw from serverservice

### DIFF
--- a/internal/inventory/serverservice.go
+++ b/internal/inventory/serverservice.go
@@ -115,8 +115,9 @@ func (s *ServerService) Publish(ctx context.Context, cfv *serverservice.Componen
 	cfv.RepositoryURL = artifactsURL
 
 	params := serverservice.ComponentFirmwareVersionListParams{
-		Vendor:  cfv.Vendor,
-		Version: cfv.Version,
+		Vendor:   cfv.Vendor,
+		Version:  cfv.Version,
+		Filename: cfv.Filename,
 	}
 
 	firmwares, _, err := s.client.ListServerComponentFirmware(ctx, &params)


### PR DESCRIPTION
When publishing firmware to serverservice make sure to filter on the filename to verify if the firmware already exists.