### PR TITLE
Update goreleaser deprecated options

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   goreleaser:
@@ -13,34 +13,28 @@ jobs:
       id-token: write
       packages: write
     steps:
-      -
-        name: Login to GHCR
+      - name: Login to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.19
-      -
-        name: install cosign
+      - name: install cosign
         uses: sigstore/cosign-installer@main
-      -
-        uses: anchore/sbom-action/download-syft@v0.14.3
-      -
-        name: Run GoReleaser
+      - uses: anchore/sbom-action/download-syft@v0.14.3
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,8 +4,7 @@ before:
     - go mod download
 
 builds:
-  -
-    id: go
+  - id: go
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,22 +19,22 @@ builds:
       - -X go.hollow.sh/toolbox/version.builtBy=goreleaser
 
 archives:
-  -
-    id: go
+  - id: go
     format: tar.gz
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
+    name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}64bit
+      {{- else if eq .Arch "386" }}32bit
+      {{- else if eq .Arch "arm" }}ARM
+      {{- else if eq .Arch "arm64" }}ARM64
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - README.md
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .Tag }}-next"
@@ -44,12 +43,11 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 
 dockers:
-  -
-    image_templates:
+  - image_templates:
       - "ghcr.io/metal-toolbox/{{.ProjectName}}:{{ .Tag }}"
       - "ghcr.io/metal-toolbox/{{.ProjectName}}:latest"
     dockerfile: Dockerfile


### PR DESCRIPTION
- `--rm-dist` was replaced to --clean
- archives.replacements removed on 2023-06-06 (https://goreleaser.com/deprecations/#archivesreplacements)