### PR TITLE
vendors/dell: add missing / separator in repository url

### DIFF
--- a/internal/vendors/dell/dell.go
+++ b/internal/vendors/dell/dell.go
@@ -88,7 +88,7 @@ func (d *DUP) Stats() *vendors.Metrics {
 func (d *DUP) Sync(ctx context.Context) error {
 	for _, fw := range d.firmwares {
 		dstPath := vendors.DstPath(fw)
-		dstURL := "s3://" + d.dstCfg.Bucket + dstPath
+		dstURL := "s3://" + d.dstCfg.Bucket + "/" + dstPath
 
 		d.logger.WithFields(
 			logrus.Fields{


### PR DESCRIPTION
This is a quick fix for the repository_url for dell firmware
` "repository_url": "https://artifacts.platformequinix.com/firmware/filesdell/BIOS_2R28V_WN64_2.19.1.EXE",   `