### PR TITLE
FS-1180 Fix for updating firmware with multiple models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.48.0
+        version: v1.55.2
         args: --config .golangci.yml --timeout=5m
 
     - name: Run firmware-syncer tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     name: 🏗️  Lint, test and build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.19
+    - name: Set up Go 1.21
       uses: actions/setup-go@v4
       with:
-        go-version: '1.19'
+        go-version: '1.21'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
     if: ( contains(github.ref, 'tags') && ! contains(github.ref, 'staging') )
     needs: lint-test-build-artifacts
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.21'
         id: go
 
       - name: Set git token env var

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
       - name: install cosign
         uses: sigstore/cosign-installer@main
       - uses: anchore/sbom-action/download-syft@v0.14.3

--- a/internal/inventory/serverservice.go
+++ b/internal/inventory/serverservice.go
@@ -143,7 +143,7 @@ func (s *serverService) Publish(ctx context.Context, newFirmware *serverservice.
 }
 
 func mergeModels(models1, models2 []string) []string {
-	var allModels []string
+	allModels := []string(nil)
 	modelsSet := make(map[string]bool)
 
 	for _, model := range models1 {
@@ -154,7 +154,7 @@ func mergeModels(models1, models2 []string) []string {
 		modelsSet[model] = true
 	}
 
-	for model, _ := range modelsSet {
+	for model := range modelsSet {
 		allModels = append(allModels, model)
 	}
 

--- a/internal/inventory/serverservice.go
+++ b/internal/inventory/serverservice.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/url"
 	"path"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/coreos/go-oidc"
@@ -113,26 +115,52 @@ func (s *serverService) Publish(ctx context.Context, newFirmware *serverservice.
 			uuids[i] = firmwares[i].UUID.String()
 		}
 
-		uuidLog := strings.Join(uuids, ",")
-
-		s.logger.WithField("uuids", uuidLog).
+		s.logger.WithField("matchingUUIDs", uuids).
 			WithField("checksum", newFirmware.Checksum).
+			WithField("firmware", newFirmware.Filename).
+			WithField("vendor", newFirmware.Vendor).
+			WithField("version", newFirmware.Version).
 			Error("Multiple firmware IDs found with checksum")
 
-		return errors.Wrap(ErrServerServiceDuplicateFirmware, uuidLog)
+		return errors.Wrap(ErrServerServiceDuplicateFirmware, strings.Join(uuids, ","))
 	}
 
-	newFirmware.UUID = firmwares[0].UUID
+	currentFirmware := &firmwares[0]
+	newFirmware.UUID = currentFirmware.UUID
+	newFirmware.Model = mergeModels(currentFirmware.Model, newFirmware.Model)
 
-	if isDifferent(newFirmware, &firmwares[0]) {
+	if isDifferent(newFirmware, currentFirmware) {
 		return s.updateFirmware(ctx, newFirmware)
 	}
 
 	s.logger.WithField("firmware", newFirmware.Filename).
+		WithField("uuid", newFirmware.UUID).
 		WithField("vendor", newFirmware.Vendor).
+		WithField("version", newFirmware.Version).
 		Debug("Firmware already exists and is up to date")
 
 	return nil
+}
+
+func mergeModels(models1, models2 []string) []string {
+	var allModels []string
+	modelsSet := make(map[string]bool)
+
+	for _, model := range models1 {
+		modelsSet[model] = true
+	}
+
+	for _, model := range models2 {
+		modelsSet[model] = true
+	}
+
+	for model, _ := range modelsSet {
+		allModels = append(allModels, model)
+	}
+
+	sort.Strings(allModels) // For consistent ordering
+
+	return allModels
 }
 
 func isDifferent(firmware1, firmware2 *serverservice.ComponentFirmwareVersion) bool {
@@ -164,7 +192,7 @@ func isDifferent(firmware1, firmware2 *serverservice.ComponentFirmwareVersion) b
 		return true
 	}
 
-	if strings.Join(firmware1.Model, ",") != strings.Join(firmware2.Model, ",") {
+	if !slices.Equal(firmware1.Model, firmware2.Model) {
 		return true
 	}
 
@@ -172,14 +200,13 @@ func isDifferent(firmware1, firmware2 *serverservice.ComponentFirmwareVersion) b
 }
 
 func (s *serverService) createFirmware(ctx context.Context, firmware *serverservice.ComponentFirmwareVersion) error {
-	id, response, err := s.client.CreateServerComponentFirmware(ctx, *firmware)
-
+	id, _, err := s.client.CreateServerComponentFirmware(ctx, *firmware)
 	if err != nil {
 		return errors.Wrap(ErrServerServiceQuery, "CreateServerComponentFirmware: "+err.Error())
 	}
 
-	s.logger.WithField("response", response).
-		WithField("firmware", firmware.Filename).
+	s.logger.WithField("firmware", firmware.Filename).
+		WithField("version", firmware.Version).
 		WithField("vendor", firmware.Vendor).
 		WithField("uuid", id).
 		Info("Created firmware")
@@ -188,14 +215,15 @@ func (s *serverService) createFirmware(ctx context.Context, firmware *serverserv
 }
 
 func (s *serverService) updateFirmware(ctx context.Context, firmware *serverservice.ComponentFirmwareVersion) error {
-	response, err := s.client.UpdateServerComponentFirmware(ctx, firmware.UUID, *firmware)
+	_, err := s.client.UpdateServerComponentFirmware(ctx, firmware.UUID, *firmware)
 	if err != nil {
 		return errors.Wrap(ErrServerServiceQuery, "UpdateServerComponentFirmware: "+err.Error())
 	}
 
 	s.logger.WithField("firmware", firmware.Filename).
+		WithField("uuid", firmware.UUID).
+		WithField("version", firmware.Version).
 		WithField("vendor", firmware.Vendor).
-		WithField("response", response).
 		Info("Updated firmware")
 
 	return nil

--- a/internal/inventory/serverservice_test.go
+++ b/internal/inventory/serverservice_test.go
@@ -8,13 +8,121 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/metal-toolbox/firmware-syncer/internal/config"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+
+	"github.com/metal-toolbox/firmware-syncer/internal/config"
 )
 
+type testCase struct {
+	name             string
+	existingFirmware *serverservice.ComponentFirmwareVersion
+	newFirmware      *serverservice.ComponentFirmwareVersion
+	expectedFirmware *serverservice.ComponentFirmwareVersion
+}
+
+var idString = "e2458c5e-bf0b-11ee-815a-f76c5993e3ca"
+
 func TestServerServicePublish(t *testing.T) {
+	id, err := uuid.Parse(idString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []*testCase{
+		{
+			"Post New Firmware",
+			nil,
+			&serverservice.ComponentFirmwareVersion{
+				Vendor:      "vendor",
+				Model:       []string{"model1", "model2"},
+				Filename:    "filename.zip",
+				Version:     "1.2.3",
+				Component:   "bmc",
+				Checksum:    "1234",
+				UpstreamURL: "http://some/location",
+			},
+			&serverservice.ComponentFirmwareVersion{
+				Vendor:        "vendor",
+				Model:         []string{"model1", "model2"},
+				Filename:      "filename.zip",
+				Version:       "1.2.3",
+				Component:     "bmc",
+				Checksum:      "1234",
+				UpstreamURL:   "http://some/location",
+				RepositoryURL: "https://example.com/some/path/vendor/filename.zip",
+			},
+		},
+		{
+			"Existing Firmware",
+			&serverservice.ComponentFirmwareVersion{
+				UUID:          id,
+				Vendor:        "vendor",
+				Model:         []string{"model1", "model2"},
+				Filename:      "filename.zip",
+				Version:       "1.2.3",
+				Component:     "bmc",
+				Checksum:      "1234",
+				UpstreamURL:   "http://some/location",
+				RepositoryURL: "https://example.com/some/path/vendor/filename.zip",
+			},
+			&serverservice.ComponentFirmwareVersion{
+				Vendor:      "vendor",
+				Model:       []string{"model2"},
+				Filename:    "filename.zip",
+				Version:     "1.2.3",
+				Component:   "bmc",
+				Checksum:    "1234",
+				UpstreamURL: "http://some/location",
+			},
+			nil,
+		},
+		{
+			"Update existing Firmware",
+			&serverservice.ComponentFirmwareVersion{
+				UUID:          id,
+				Vendor:        "vendor",
+				Model:         []string{"model1", "model3"},
+				Filename:      "filename.zip",
+				Version:       "1.2.3",
+				Component:     "bmc",
+				Checksum:      "1234",
+				UpstreamURL:   "http://some/location",
+				RepositoryURL: "https://example.com/some/path/vendor/filename.zip",
+			},
+			&serverservice.ComponentFirmwareVersion{
+				Vendor:      "vendor",
+				Model:       []string{"model2", "model4"},
+				Filename:    "filename.zip",
+				Version:     "1.2.4",
+				Component:   "bmc",
+				Checksum:    "1234",
+				UpstreamURL: "http://some/location",
+			},
+			&serverservice.ComponentFirmwareVersion{
+				UUID:          id,
+				Vendor:        "vendor",
+				Model:         []string{"model1", "model2", "model3", "model4"},
+				Filename:      "filename.zip",
+				Version:       "1.2.4",
+				Component:     "bmc",
+				Checksum:      "1234",
+				UpstreamURL:   "http://some/location",
+				RepositoryURL: "https://example.com/some/path/vendor/filename.zip",
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			testServerServicePublish(t, tt)
+		})
+	}
+}
+
+func testServerServicePublish(t *testing.T, tt *testCase) {
 	handler := http.NewServeMux()
 	handler.HandleFunc(
 		"/api/v1/server-component-firmwares",
@@ -23,25 +131,75 @@ func TestServerServicePublish(t *testing.T) {
 			case http.MethodGet:
 				w.Header().Set("Content-Type", "application/json")
 
-				_, _ = w.Write([]byte(`{}`))
+				serverResponse := &serverservice.ServerResponse{}
+
+				if tt.existingFirmware != nil {
+					serverResponse.Records = []*serverservice.ComponentFirmwareVersion{
+						tt.existingFirmware,
+					}
+				}
+
+				responseBytes, err := json.Marshal(serverResponse)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if _, err = w.Write(responseBytes); err != nil {
+					t.Fatal(err)
+				}
 			case http.MethodPost:
 				b, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				cfv := &serverservice.ComponentFirmwareVersion{}
-				if err = json.Unmarshal(b, cfv); err != nil {
+				newFirmware := &serverservice.ComponentFirmwareVersion{}
+				if err = json.Unmarshal(b, newFirmware); err != nil {
 					t.Fatal(err)
 				}
 
-				// assert what we're publishing to serverservice is sane
-				assert.Equal(t, "https://example.com/some/path/vendor/filename.zip", cfv.RepositoryURL)
+				if tt.expectedFirmware != nil {
+					assert.Equal(t, tt.expectedFirmware, newFirmware)
+				} else {
+					t.Fatal("No firmware POST expected")
+				}
 
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write(b)
+
+				if _, err = w.Write(b); err != nil {
+					t.Fatal(err)
+				}
 			default:
 				t.Fatal("unexpected request method, got: " + r.Method)
+			}
+		},
+	)
+	handler.HandleFunc(
+		"/api/v1/server-component-firmwares/"+idString,
+		func(writer http.ResponseWriter, request *http.Request) {
+			switch request.Method {
+			case http.MethodPut:
+				b, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				updatedFirmware := &serverservice.ComponentFirmwareVersion{}
+				if err = json.Unmarshal(b, updatedFirmware); err != nil {
+					t.Fatal(err)
+				}
+
+				if tt.expectedFirmware != nil {
+					assert.Equal(t, tt.expectedFirmware, updatedFirmware)
+				} else {
+					t.Fatal("No firmware PUT expected")
+				}
+
+				writer.Header().Set("Content-Type", "application/json")
+
+				if _, err = writer.Write(b); err != nil {
+					t.Fatal(err)
+				}
 			}
 		},
 	)
@@ -59,22 +217,12 @@ func TestServerServicePublish(t *testing.T) {
 	logger := logrus.New()
 	logger.Out = io.Discard
 
-	hss, err := New(context.TODO(), &cfg, artifactsURL, logger)
+	hss, err := New(context.Background(), &cfg, artifactsURL, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cfv := serverservice.ComponentFirmwareVersion{
-		Vendor:      "vendor",
-		Model:       []string{"model1", "model2"},
-		Filename:    "filename.zip",
-		Version:     "1.2.3",
-		Component:   "bmc",
-		Checksum:    "1234",
-		UpstreamURL: "http://some/location",
-	}
-
-	err = hss.Publish(context.TODO(), &cfv)
+	err = hss.Publish(context.Background(), tt.newFirmware)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vendors/syncer.go
+++ b/internal/vendors/syncer.go
@@ -66,6 +66,7 @@ func (s *Syncer) syncFirmware(ctx context.Context, firmware *serverservice.Compo
 
 	logMsg := s.logger.WithField("firmware", firmware.Filename).
 		WithField("vendor", firmware.Vendor).
+		WithField("version", firmware.Version).
 		WithField("url", firmware.UpstreamURL)
 
 	logMsg.Info("Syncing Firmware")


### PR DESCRIPTION
Firmware-syncer is not properly handling updating firmware with multiple models. Existing models are being overwritten.

This change fixes the issue by merging the new and existing models together into a set-like structure (to eliminate duplicates), then converting to a sorted slice (to compare slices), and then comparing the new and existing slices for differences.

Also in this change:
- Enhanced some tests to reproduce the issue and validate the fix
- Enhanced some logging
- Updated version of Go from 1.19 to 1.21 to use newer packages
- Updated version of golangci-lint to 1.55.2 (latest) to fix linter